### PR TITLE
新しいビルド設定とパッケージの追加、コードのリファクタリング

### DIFF
--- a/BlazorServerChat2.sln
+++ b/BlazorServerChat2.sln
@@ -7,10 +7,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorServerChat2", "Blazor
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		aaaa|Any CPU = aaaa|Any CPU
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EBA14433-7054-49A0-9C4C-EC587F530AA1}.aaaa|Any CPU.ActiveCfg = aaaa|Any CPU
+		{EBA14433-7054-49A0-9C4C-EC587F530AA1}.aaaa|Any CPU.Build.0 = aaaa|Any CPU
 		{EBA14433-7054-49A0-9C4C-EC587F530AA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EBA14433-7054-49A0-9C4C-EC587F530AA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EBA14433-7054-49A0-9C4C-EC587F530AA1}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/BlazorServerChat2/BlazorServerChat2.csproj
+++ b/BlazorServerChat2/BlazorServerChat2.csproj
@@ -7,30 +7,32 @@
 		<UserSecretsId>aspnet-BlazorServerChat2-F0A9D83A-563B-466C-9E4C-6FA6E84CEE5D</UserSecretsId>
 		<ApplicationInsightsResourceId>/subscriptions/de4b03f6-f324-4e64-ac59-f00e453f31fa/resourceGroups/abiyaapplicationInsight/providers/microsoft.insights/components/BlazorServerChat2</ApplicationInsightsResourceId>
 		<AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
+		<Configurations>Debug;Release;aaaa</Configurations>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0" />
+		<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.1" />
 		<PackageReference Include="Blazor.Markdown" Version="1.0.0" />
-		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.0" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.4" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.4" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.4" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.4" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
-		<PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.0.0" />
-		<PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.0.0" />
-		<PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.0.0" />
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.0.0-rc3" />
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
-		<PackageReference Include="Radzen.Blazor" Version="4.21.3" />
+		<PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.7.2" />
+		<PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.6.0" />
+		<PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.7.2" />
+		<PackageReference Include="Microsoft.SemanticKernel" Version="1.10.0" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+		<PackageReference Include="Radzen.Blazor" Version="4.31.1" />
 	</ItemGroup>
 
 </Project>

--- a/BlazorServerChat2/Pages/Index.razor
+++ b/BlazorServerChat2/Pages/Index.razor
@@ -191,9 +191,9 @@ else
                         <FluentGridItem lg="1" md="1" sm="1" xl="1" xs="1" xxl="1">
                             <FluentStack VerticalAlignment="VerticalAlignment.Center" HorizontalAlignment="HorizontalAlignment.Center">
                                 <div>
-                                    @if (@DbContext.UserChatSetting.Where(x => x.Id == @item.UserId).Select(x => x.IconNumber).FirstOrDefault() != 0)
+                                    @if (@DbContext.UserChatSetting.Find(item.UserId) is not null && @DbContext.UserChatSetting.Find(item.UserId)!.IconNumber != 0)
                                     {
-                                        <img src="data:image/png;base64,@Convert.ToBase64String(@DbContext.IconMaster.Where(x => x.IconNumber == @DbContext.UserChatSetting.Where(x => x.Id == @item.UserId).Select(x => x.IconNumber).FirstOrDefault()).Select(x => x.Icon).FirstOrDefault()!)" />
+                                        <img src="data:image/png;base64,@Convert.ToBase64String(@DbContext.IconMaster.Where(x  => x.IconNumber == (DbContext.UserChatSetting.Find(@item.UserId)!).IconNumber).Select(x => x.Icon).First()!)" />
                                     }
                                     else
                                     {
@@ -243,9 +243,9 @@ else
                                 <FluentGridItem lg="1" md="1" sm="1" xl="1" xs="1" xxl="1">
                                     <FluentStack VerticalAlignment="VerticalAlignment.Center" HorizontalAlignment="HorizontalAlignment.Center">
                                         <div>
-                                            @if (@DbContext.UserChatSetting.Where(x => x.Id == @item.UserId).Select(x => x.IconNumber).FirstOrDefault() != 0)
+                                    @if (@DbContext.UserChatSetting.Find(item.UserId) is not null && @DbContext.UserChatSetting.Find(item.UserId)!.IconNumber != 0)
                                             {
-                                                <img src="data:image/png;base64,@Convert.ToBase64String(@DbContext.IconMaster.Where(x => x.IconNumber == @DbContext.UserChatSetting.Where(x => x.Id == @item.UserId).Select(x => x.IconNumber).FirstOrDefault()).Select(x => x.Icon).FirstOrDefault()!)" />
+                                        <img src="data:image/png;base64,@Convert.ToBase64String(@DbContext.IconMaster.Where(x  => x.IconNumber == (DbContext.UserChatSetting.Find(@item.UserId)!).IconNumber).Select(x => x.Icon).First()!)" />
                                             }
                                             else
                                             {

--- a/BlazorServerChat2/Program.cs
+++ b/BlazorServerChat2/Program.cs
@@ -40,8 +40,8 @@ var redis = ConnectionMultiplexer.Connect(RedisConnString);
 builder.Services.AddSession(options =>
 {
     options.Cookie.Name = "YourAppCookieName";
-    options.IdleTimeout = TimeSpan.FromDays(1000);
-    options.Cookie.HttpOnly = true;
+    options.IdleTimeout = TimeSpan.FromSeconds(10);
+    options.Cookie.IsEssential = true;
 
 });
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
@@ -54,25 +54,25 @@ builder.Services.AddDefaultIdentity<IdentityUser>(options =>
 })
     .AddEntityFrameworkStores<ApplicationDbContext>();
 
-builder.Services.ConfigureApplicationCookie(options =>
-{
-    options.AccessDeniedPath = "/Identity/Account/AccessDenied";
-    options.Cookie.Name = "YourAppCookieName";
-    options.Cookie.HttpOnly = true;
-    options.ExpireTimeSpan = TimeSpan.FromDays(1000);
+//builder.Services.ConfigureApplicationCookie(options =>
+//{
+//    options.AccessDeniedPath = "/Identity/Account/AccessDenied";
+//    options.Cookie.Name = "YourAppCookieName";
+//    options.ExpireTimeSpan = TimeSpan.FromDays(1000);
 
-    options.LoginPath = "/Identity/Account/Login";
-    // ReturnUrlParameter requires 
-    //using Microsoft.AspNetCore.Authentication.Cookies;
-    options.ReturnUrlParameter = CookieAuthenticationDefaults.ReturnUrlParameter;
-    options.SlidingExpiration = true;
-});
+//    options.LoginPath = "/Identity/Account/Login";
+//    // ReturnUrlParameter requires 
+//    //using Microsoft.AspNetCore.Authentication.Cookies;
+//    options.ReturnUrlParameter = CookieAuthenticationDefaults.ReturnUrlParameter;
+//    options.SlidingExpiration = true;
+//});
 
 builder.Services.Configure<SecurityStampValidatorOptions>(options =>
 {
     options.ValidationInterval = TimeSpan.FromDays(3);
 
 });
+builder.Services.AddOpenTelemetry();
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 builder.Services.AddHttpClient();
@@ -96,6 +96,7 @@ builder.Logging.AddFilter("Microsoft.EntityFrameworkCore", LogLevel.Error);
 builder.Services.AddApplicationInsightsTelemetry();
 
 var app = builder.Build();
+
 var _telemetryClient = app.Services.GetRequiredService<TelemetryClient>();
 
 var meterListener = new MeterListener();


### PR DESCRIPTION
新しいビルド設定 `aaaa|Any CPU` と `aaaa` がそれぞれ `BlazorServerChat2.sln` と `BlazorServerChat2.csproj` に追加されました。また、`BlazorServerChat2.csproj` では、いくつかのパッケージがアップデートされ、新しいパッケージ `OpenTelemetry.Extensions.Hosting` が追加されました。`SemanticKernelLogic.cs` では、`using` ステートメントの変更、`MeterListener` と `StartOperation` のコメントアウト、`KernelBuilder` の設定変更、メソッド呼び出し結果の型変更が行われました。`Index.razor` では、ユーザーアイコン取得の条件とクエリが変更されました。最後に、`Program.cs` では、セッションの `IdleTimeout` と `HttpOnly` の設定変更、`ConfigureApplicationCookie` のコメントアウト、`AddOpenTelemetry` の追加、`TelemetryClient` の取得が行われました。